### PR TITLE
Add --error-on-fail flag to exit with error code when test suite failed

### DIFF
--- a/bin/spook
+++ b/bin/spook
@@ -111,6 +111,9 @@ if(argv.server) {
       } else {
         formatter(res);
         ghost('Spook run took ' + res.DU + 's');
+        if(res.TO.ST === 'FAIL' && argv['error-on-fail']) {
+          process.exit(1);
+        }
       }
     });
   });


### PR DESCRIPTION
We've hooked spook up to perform integration tests on CircleCI for pull requests. Unfortunately, while the test suite runs successfully, spook doesn't have a way to expose whether the suite passed or failed. To enable this without breaking legacy installations, I added an `--error-on-fail` flag which, if set, will `exit 1` in the event of failed tests. If you have a better solution that I should use, just let me know.